### PR TITLE
Force the character encoding to UTF-8 when compiling and running tests.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -91,9 +91,12 @@
   <target name="test" depends="build">
     <mkdir dir="${builddir}/tests"/>
     <javac fork="true" debug="on" srcdir="tests/" destdir="${builddir}/tests"
-           classpath="tests/lib/*:${toString:classpath}" />
+           classpath="tests/lib/*:${toString:classpath}">
+      <compilerarg line="-encoding UTF-8" />
+    </javac>
 
     <junit showoutput="yes" fork="true">
+      <jvmarg value="-Dfile.encoding=UTF-8" />
       <classpath>
         <pathelement location="tests/lib/junit-4.11.jar"/>
         <pathelement location="tests/lib/*"/>


### PR DESCRIPTION
Avoids failures due to locale settings on the machine running the tests.
