### PR TITLE
require Java 1.7

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -4,6 +4,9 @@
   <property name="build.sysclasspath" value="last"/>
   <property name="solr.war" value="../solr/jetty/webapps/solr.war"/>
   <property name="solr.dir" value="../solr/jetty/webapps/solr/"/>
+  <property name="java.compat.version" value="1.7"/>
+  <property name="ant.build.javac.source" value="1.7"/>
+  <property name="ant.build.javac.target" value="1.7"/>
 
   <path id="classpath">
     <pathelement location="${builddir}/common"/>


### PR DESCRIPTION
Since solrmarc requirement is increasing, we should also set java 1.7 for the browse handler.

ant compile and tests run fine.