### PR TITLE
NACO normalizer

### DIFF
--- a/browse-indexing/CreateBrowseSQLite.java
+++ b/browse-indexing/CreateBrowseSQLite.java
@@ -3,7 +3,6 @@
 //
 
 import java.io.*;
-import java.util.*;
 
 import java.sql.*;
 

--- a/browse-indexing/Leech.java
+++ b/browse-indexing/Leech.java
@@ -2,7 +2,6 @@ import org.apache.lucene.store.*;
 import org.apache.lucene.index.*;
 import org.apache.lucene.search.*;
 import java.io.*;
-import java.util.*;
 
 import org.vufind.util.BrowseEntry;
 import org.vufind.util.Normalizer;

--- a/browse-indexing/PrintBrowseHeadings.java
+++ b/browse-indexing/PrintBrowseHeadings.java
@@ -3,16 +3,12 @@
 //
 
 import java.io.*;
-import java.util.*;
-import java.util.regex.*;
 import java.nio.charset.*;
 
 import org.apache.lucene.store.*;
 import org.apache.lucene.search.*;
 import org.apache.lucene.index.*;
 import org.apache.lucene.document.*;
-
-import java.sql.*;
 
 import org.vufind.util.BrowseEntry;
 
@@ -23,7 +19,6 @@ import org.apache.commons.codec.binary.Base64;
 public class PrintBrowseHeadings
 {
     private Leech bibLeech;
-    private Leech authLeech;
     private Leech nonprefAuthLeech;
 
     IndexSearcher bibSearcher;

--- a/build.xml
+++ b/build.xml
@@ -2,6 +2,8 @@
 
   <property name="builddir" location="build"/>
   <property name="build.sysclasspath" value="last"/>
+  <property name="testdir" value="${builddir}/tests"/>
+  <property name="testoutputdir" value="${testdir}/output"/>
   <property name="solr.war" value="../solr/jetty/webapps/solr.war"/>
   <property name="solr.dir" value="../solr/jetty/webapps/solr/"/>
   <property name="java.compat.version" value="1.7"/>
@@ -92,8 +94,10 @@
   </target>
 
   <target name="test" depends="build">
-    <mkdir dir="${builddir}/tests"/>
-    <javac fork="true" debug="on" srcdir="tests/" destdir="${builddir}/tests"
+      <mkdir dir="${testdir}"/>
+      <mkdir dir="${testoutputdir}"/>
+      <mkdir dir="${testdir}/report"/>
+    <javac fork="true" debug="on" srcdir="tests/" destdir="${testdir}"
            classpath="tests/lib/*:${toString:classpath}:${builddir}/browse-handler">
       <compilerarg line="-encoding UTF-8" />
     </javac>
@@ -103,16 +107,28 @@
       <classpath>
         <pathelement location="tests/lib/junit-4.11.jar"/>
         <pathelement location="tests/lib/*"/>
-        <pathelement location="${builddir}/tests"/>
+        <pathelement location="${testdir}"/>
         <pathelement location="${builddir}/browse-handler"/>
         <pathelement path="${toString:classpath}"/>
       </classpath>
-      <formatter type="plain" usefile="false"/>
-      <batchtest>
+      <!-- formatter type="plain" usefile="false"/-->
+      <batchtest todir="${testoutputdir}">
         <fileset dir="tests">
-	  <include name="**/*.java"/>
+          <include name="**/*.java"/>
         </fileset>
+        <formatter type="xml" usefile="yes"/>
+        <formatter type="plain" usefile="yes"/>
+        <formatter type="brief" usefile="no"/>
       </batchtest>
     </junit>
+      
+    <junitreport todir="${testdir}/report">
+      <fileset dir="${testoutputdir}">
+        <include name="TEST-*.xml"/>
+      </fileset>
+      <report format="frames" todir="${testdir}/report"/>
+    </junitreport>
+    <echo message="JUnit reports available in ${testdir}/report"></echo>
+
   </target>
 </project>

--- a/common/java/org/vufind/util/ICUCollatorNormalizer.java
+++ b/common/java/org/vufind/util/ICUCollatorNormalizer.java
@@ -2,6 +2,7 @@ package org.vufind.util;
 
 import java.util.regex.*;
 
+import com.ibm.icu.text.CollationKey;
 import com.ibm.icu.text.Collator;
 
 /**
@@ -47,8 +48,8 @@ public class ICUCollatorNormalizer implements Normalizer
         return iCUCollatorNormalizer;
     }
 
-
-    public byte[] normalize (String s)
+    // Breaking out the CollationKey makes testing and debugging easier 
+    public CollationKey normalizeToKey (String s)
     {
         s = s.replaceAll ("-", "")
             .replaceAll ("\\p{Punct}", " ")
@@ -57,6 +58,11 @@ public class ICUCollatorNormalizer implements Normalizer
 
         s = junkregexp.matcher (s) .replaceAll ("");
 
-        return collator.getCollationKey (s).toByteArray ();
+        return collator.getCollationKey (s);
+    }
+
+    public byte[] normalize (String s)
+    {
+        return normalizeToKey (s).toByteArray ();
     }
 }

--- a/common/java/org/vufind/util/ICUCollatorNormalizer.java
+++ b/common/java/org/vufind/util/ICUCollatorNormalizer.java
@@ -1,9 +1,6 @@
 package org.vufind.util;
 
-import java.io.*;
-import java.util.*;
 import java.util.regex.*;
-import org.vufind.util.*;
 
 import com.ibm.icu.text.Collator;
 

--- a/common/java/org/vufind/util/NACONormalizer.java
+++ b/common/java/org/vufind/util/NACONormalizer.java
@@ -1,0 +1,143 @@
+package org.vufind.util;
+
+import java.util.regex.Pattern;
+
+import com.ibm.icu.text.CollationKey;
+import com.ibm.icu.text.Collator;
+
+/**
+ * Browse normalizer which implements the NACO Normalization Rules.
+ * 
+ * This class diverges from the NACO Normalization Rules:
+ * 
+ * Additional normalization:
+ * <ol>
+ * <li>
+ * left and right single and double quotes
+ * </li>
+ * </ol>
+ * 
+ * Not yet implemented:
+ * <ol>
+ * <li>
+ * commas: all commas are converted to blanks, first comma in ‡a is <em>not</em> retained
+ * </li>
+ * <li>
+ * eszedt, thorn, and eth are not normalized to their two-character equivalents
+ * </li>
+ * <li>
+ * Inverted question mark is not normalized
+ * </li>
+ * <li>
+ * </li>
+ * </ol>
+ * 
+ * 
+ * <p>Based on {@link ICUCollatorNormalizer}, by Mark Triggs</p>
+ * 
+ * @author Tod Olson, University of Chicago
+ *
+ * @see <a href="http://www.loc.gov/aba/pcc/naco/normrule-2.html">Authority File Comparison Rules (NACO Normalization)</a>
+ */
+
+public class NACONormalizer implements Normalizer {
+    protected Collator collator;
+    
+    /**
+     * Characters that will be deleted during normalization.
+     */
+    static private String deleteChars = "['\\[\\]\u02BA\u02BB\u02BC\u02B9]";
+
+    /**
+     * Characters that will be converted to spaces during normalization.
+     */
+    static private String spaceChars = "[\\p{Punct}¿¡‘’“”±⁺⁻℗®©°·]";
+
+    /**
+     * Pattern to match characters that will be deleted during normalization.
+     */
+    static private Pattern deletePattern = Pattern.compile(deleteChars);
+
+    /**
+     * Pattern to match characters to treat as spaces during normalization.
+     */
+    static private Pattern spacePattern = Pattern.compile(spaceChars);
+    
+    /**
+     * Pattern for squashing repeated whitespace to a single character.
+     */
+    static private Pattern whitespacePattern = Pattern.compile("\\s+");
+    
+    public NACONormalizer() {
+        collator = Collator.getInstance();
+        // Ignore case and diacritics for the purposes of comparisons.
+        // Use PRIMARY unless we prove we need something different
+        collator.setStrength(Collator.PRIMARY);
+ 
+    }
+
+    // TODO: remove getInstance when no longer needed
+    public static NACONormalizer getInstance () throws Exception
+    {
+        NACONormalizer nacoNormalizer;
+
+        if (Utils.getEnvironment ("NORMALISER") != null) {
+            String normalizerClass = Utils.getEnvironment("NORMALISER");
+
+            nacoNormalizer = (NACONormalizer) (Class.forName(normalizerClass)
+                        .getConstructor()
+                        .newInstance());
+        } else {
+            nacoNormalizer = new NACONormalizer();
+        }
+
+        return nacoNormalizer;
+    }
+
+    /**
+     * Computes ICU collation key for the input string.
+     * 
+     * <p>Breaking out the CollationKey makes testing and debugging easier.</p>
+     * 
+     * <p>
+     * Implementation note:
+     * Using cached patterns rather than {@code String#replaceAll} seems to speed up
+     * key production significantly, roughly 20% in {@code main()}.
+     * </p>
+     * 
+     * @param string to normalize
+     * @return collation key object
+     */
+    public CollationKey normalizeToKey (String s)
+    {
+        s = deletePattern.matcher(s).replaceAll("");
+        s = spacePattern.matcher(s).replaceAll(" ");
+        s = whitespacePattern.matcher(s).replaceAll(" ");
+        s = s.trim();
+        return collator.getCollationKey (s);
+    }
+
+    public byte[] normalize (String s)
+    {
+        return normalizeToKey (s).toByteArray ();
+    }
+    
+    /**
+     * Read lines from stdin and write normalize output to stdout.
+     * Useful for benchmarking, debugging.
+     */
+    public static void main(String[] args) {
+        try {
+            NACONormalizer norm = new NACONormalizer();
+            
+            java.io.InputStreamReader in= new java.io.InputStreamReader(System.in);
+            java.io.BufferedReader input = new java.io.BufferedReader(in);
+            String str;
+            while ((str = input.readLine()) != null) {
+                System.out.println(norm.normalize(str));
+            }
+        } catch (java.io.IOException io) {
+            io.printStackTrace();
+        }
+    }
+}

--- a/common/java/org/vufind/util/NACONormalizer.java
+++ b/common/java/org/vufind/util/NACONormalizer.java
@@ -16,6 +16,11 @@ import com.ibm.icu.text.Collator;
  * left and right single and double quotes
  * </li>
  * <li>
+ * European-style quotes, «»:<br>
+ * LEFT-POINTING DOUBLE ANGLE QUOTATION MARK &lt;U+00AB><br>
+ * RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK &lt;U+00BB>
+ * </li>
+ * <li>
  * MODIFIER LETTER LEFT HALF RING <U02BF>
  * </li>
  * </ol>
@@ -54,7 +59,7 @@ public class NACONormalizer implements Normalizer {
     /**
      * Characters that will be converted to spaces during normalization.
      */
-    static private String spaceChars = "[\\p{Punct}¿¡‘’“”±⁺⁻℗®©°·]";
+    static private String spaceChars = "[\\p{Punct}¿¡‘’“”«»±⁺⁻℗®©°·]";
 
     /**
      * Pattern to match characters that will be deleted during normalization.

--- a/common/java/org/vufind/util/NACONormalizer.java
+++ b/common/java/org/vufind/util/NACONormalizer.java
@@ -15,6 +15,9 @@ import com.ibm.icu.text.Collator;
  * <li>
  * left and right single and double quotes
  * </li>
+ * <li>
+ * MODIFIER LETTER LEFT HALF RING <U02BF>
+ * </li>
  * </ol>
  * 
  * Not yet implemented:
@@ -23,7 +26,7 @@ import com.ibm.icu.text.Collator;
  * commas: all commas are converted to blanks, first comma in ‡a is <em>not</em> retained
  * </li>
  * <li>
- * eszedt, thorn, and eth are not normalized to their two-character equivalents
+ * eszedt, and thorn are not normalized to their two-character equivalents
  * </li>
  * <li>
  * Inverted question mark is not normalized
@@ -46,7 +49,7 @@ public class NACONormalizer implements Normalizer {
     /**
      * Characters that will be deleted during normalization.
      */
-    static private String deleteChars = "['\\[\\]\u02BA\u02BB\u02BC\u02B9]";
+    static private String deleteChars = "['\\[\\]\u02BA\u02BB\u02BC\u02B9\u02BF]";
 
     /**
      * Characters that will be converted to spaces during normalization.

--- a/tests/org/vufind/solr/browse/tests/NACONormalizerTest.java
+++ b/tests/org/vufind/solr/browse/tests/NACONormalizerTest.java
@@ -1,0 +1,363 @@
+package org.vufind.solr.browse.tests;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.vufind.util.NACONormalizer;
+
+public class NACONormalizerTest
+{
+    private NACONormalizer nacoNormalizer;
+
+    @Before
+    public void setUp () {
+        nacoNormalizer = new NACONormalizer ();
+    }
+
+
+    /*
+     * Begin with ICUCollatorNormalizer tests...
+     */
+    
+    @Test
+    public void sortsSimpleStrings () {
+        assertEquals (listOf ("apple", "banana", "cherry", "orange"),
+                      sort (listOf ("banana", "orange", "apple", "cherry")));
+    }
+
+
+    @Test
+    public void sortsDiacriticStrings () {
+        assertEquals (listOf ("AAA", "Äardvark", "Apple", "Banana", "grapefruit", "Orange"),
+                sort (listOf ("grapefruit", "Apple", "Orange", "AAA", "Äardvark", "Banana")));
+    }
+
+
+    @Test
+    public void handlesHyphensQuotesAndWhitespace () {
+        assertEquals (listOf ("AAA", "Äardvark", "Apple", "Banana", "grapefruit",
+                              "\"Hyphenated-words and double quotes\"",
+                              "   inappropriate leading space",
+                              "Orange"),
+                      sort (listOf ("Orange",
+                                    "\"Hyphenated-words and double quotes\"",
+                                    "Banana", "grapefruit",
+                                    "   inappropriate leading space",
+                                    "Äardvark", "Apple", "AAA")));
+
+    }
+
+    @Test
+    public void ignoresPunctuationMixedWithSpaces () {
+        assertArrayEquals (nacoNormalizer.normalize ("wharton, edith"), nacoNormalizer.normalize ("wharton edith"));
+        assertArrayEquals (nacoNormalizer.normalize ("st. john"), nacoNormalizer.normalize ("st john"));
+    }
+
+    /*
+     * Begin NACO-specific tests
+     * See http://www.loc.gov/aba/pcc/naco/normrule-2.html
+     */
+    
+    @Test
+    public void generalCharacters () {
+        // Delete leading blanks
+        assertArrayEquals (nacoNormalizer.normalize ("  The Hobbit"), nacoNormalizer.normalize ("The Hobbit"));
+        // Delete trailing blanks
+        assertArrayEquals (nacoNormalizer.normalize ("The Hobbit  "), nacoNormalizer.normalize ("The Hobbit"));
+        // Delete multiple blanks
+        assertArrayEquals (nacoNormalizer.normalize ("The   Hobbit"), nacoNormalizer.normalize ("The Hobbit"));
+        // Lowercase equivalent to upper case
+        assertArrayEquals (nacoNormalizer.normalize ("the hobbit"), nacoNormalizer.normalize ("THE HOBBIT"));
+    }
+
+    @Test
+    public void modifyingDiacritics () {
+        // *Do not confuse with spacing character equivalents (see Other Special Characters below)
+        // Acute
+        assertArrayEquals (nacoNormalizer.normalize ("écru"), nacoNormalizer.normalize ("ecru"));
+        // Breve
+        assertArrayEquals (nacoNormalizer.normalize ("gărahima"), nacoNormalizer.normalize ("garahima"));
+        // Candrabindu
+        assertArrayEquals (nacoNormalizer.normalize ("Gam̐va"), nacoNormalizer.normalize ("Gamva"));
+        // Cedilla
+        assertArrayEquals (nacoNormalizer.normalize ("façade"), nacoNormalizer.normalize ("facade"));
+        // Cedilla: COMBINING CEDILLA <U+0327>
+        assertArrayEquals (nacoNormalizer.normalize ("fa\u0327cade"), nacoNormalizer.normalize ("facade"));
+        // Cedilla: LATIN SMALL LETTER C WITH CEDILLA <U+00E7>
+        assertArrayEquals (nacoNormalizer.normalize ("fa\u00E7ade"), nacoNormalizer.normalize ("facade"));
+        // Circle above, angstrom
+        assertArrayEquals (nacoNormalizer.normalize ("angstrom"), nacoNormalizer.normalize ("angstrom"));        // Circle below
+        // Circumflex*
+        // Dot below
+        assertArrayEquals (nacoNormalizer.normalize ("arahaṃ"), nacoNormalizer.normalize ("araham"));
+        assertArrayEquals (nacoNormalizer.normalize ("Tipiṭaka"), nacoNormalizer.normalize ("Tipitaka"));
+        // Double acute
+        // Double tilde (first/second half)
+        // Double underscore
+        // Grave*
+        // Hacek
+        // High comma centered
+        // High comma off center
+        // Left hook
+        // Ligature (first/second half)vospominanii︠a︡
+        assertArrayEquals (nacoNormalizer.normalize ("vospominanii︠a︡"), nacoNormalizer.normalize ("vospominaniia"));
+        // Ligature (single) [not in NACO, but we get them in Unicode]
+        assertArrayEquals (nacoNormalizer.normalize ("Novai͡a"), nacoNormalizer.normalize ("Novaia"));
+        // Macron
+        assertArrayEquals (nacoNormalizer.normalize ("Pāli"), nacoNormalizer.normalize ("Pali"));
+        // Pseudo question mark
+        // Right cedilla
+        // Right hook, ogonek
+        // Superior dot
+        assertArrayEquals (nacoNormalizer.normalize ("piṅkama"), nacoNormalizer.normalize ("pinkama"));
+        // Tilde*
+        assertArrayEquals (nacoNormalizer.normalize ("mañana"), nacoNormalizer.normalize ("manana"));
+        // Umlaut, diaeresis
+        assertArrayEquals (nacoNormalizer.normalize ("Ümlaut"), nacoNormalizer.normalize ("Umlaut"));
+        assertArrayEquals (nacoNormalizer.normalize ("ümlaut"), nacoNormalizer.normalize ("umlaut"));
+        assertArrayEquals (nacoNormalizer.normalize ("naïve"), nacoNormalizer.normalize ("naive"));
+        assertArrayEquals (nacoNormalizer.normalize ("noël"), nacoNormalizer.normalize ("noel"));
+        // Underscore*
+        assertArrayEquals (nacoNormalizer.normalize ("Kan̲akacapai"), nacoNormalizer.normalize ("Kanakacapai"));
+        // Upadhmaniya
+    }
+    
+    @Test
+    public void translatedCharacters () {
+        // Superscript numbers     Numbers Convert to non-superscript equivalent
+        assertArrayEquals (nacoNormalizer.normalize ("zero⁰"), nacoNormalizer.normalize ("zero0"));
+        assertArrayEquals (nacoNormalizer.normalize ("one¹"), nacoNormalizer.normalize ("one1"));
+        assertArrayEquals (nacoNormalizer.normalize ("two²"), nacoNormalizer.normalize ("two2"));
+        assertArrayEquals (nacoNormalizer.normalize ("three³"), nacoNormalizer.normalize ("three3"));
+        assertArrayEquals (nacoNormalizer.normalize ("four⁴"), nacoNormalizer.normalize ("four4"));
+        assertArrayEquals (nacoNormalizer.normalize ("five⁵"), nacoNormalizer.normalize ("five5"));
+        assertArrayEquals (nacoNormalizer.normalize ("six⁶"), nacoNormalizer.normalize ("six6"));
+        assertArrayEquals (nacoNormalizer.normalize ("seven⁷"), nacoNormalizer.normalize ("seven7"));
+        assertArrayEquals (nacoNormalizer.normalize ("eight⁸"), nacoNormalizer.normalize ("eight8"));
+        assertArrayEquals (nacoNormalizer.normalize ("nine⁹"), nacoNormalizer.normalize ("nine9"));
+        // Subscript numbers       Numbers Convert to non-subscript equivalent
+        assertArrayEquals (nacoNormalizer.normalize ("zero₀"), nacoNormalizer.normalize ("zero0"));
+        assertArrayEquals (nacoNormalizer.normalize ("one₁"), nacoNormalizer.normalize ("one1"));
+        assertArrayEquals (nacoNormalizer.normalize ("two₂"), nacoNormalizer.normalize ("two2"));
+        assertArrayEquals (nacoNormalizer.normalize ("three₃"), nacoNormalizer.normalize ("three3"));
+        assertArrayEquals (nacoNormalizer.normalize ("four₄"), nacoNormalizer.normalize ("four4"));
+        assertArrayEquals (nacoNormalizer.normalize ("five₅"), nacoNormalizer.normalize ("five5"));
+        assertArrayEquals (nacoNormalizer.normalize ("six₆"), nacoNormalizer.normalize ("six6"));
+        assertArrayEquals (nacoNormalizer.normalize ("seven₇"), nacoNormalizer.normalize ("seven7"));
+        assertArrayEquals (nacoNormalizer.normalize ("eight₈"), nacoNormalizer.normalize ("eight8"));
+        assertArrayEquals (nacoNormalizer.normalize ("nine₉"), nacoNormalizer.normalize ("nine9"));
+        // Diagraph AE     AE      Upper and lower case
+        assertArrayEquals (nacoNormalizer.normalize ("Ægyptiorum"), nacoNormalizer.normalize ("AEgyptiorum"));
+        assertArrayEquals (nacoNormalizer.normalize ("dæmone"), nacoNormalizer.normalize ("daemone"));
+        // Diagraph OE     OE      Upper and lower case
+        assertArrayEquals (nacoNormalizer.normalize ("Œuvre"), nacoNormalizer.normalize ("OEuvre"));
+        assertArrayEquals (nacoNormalizer.normalize ("œuvre"), nacoNormalizer.normalize ("oeuvre"));
+        // D with crossbar D       Upper and lower case
+        assertArrayEquals (nacoNormalizer.normalize ("Đ U+0110 LATIN CAPITAL LETTER D WITH STROKE"), 
+                nacoNormalizer.normalize ("Đ U+0110 LATIN CAPITAL LETTER D WITH STROKE"));
+        assertArrayEquals (nacoNormalizer.normalize ("đ U+0111 LATIN SMALL LETTER D WITH STROKE"),
+                nacoNormalizer.normalize ("d U+0111 LATIN SMALL LETTER D WITH STROKE"));
+        assertArrayEquals (nacoNormalizer.normalize ("aliud đ notatur"), nacoNormalizer.normalize ("aliud d notatur"));
+        // Eth     D       Upper and lower case
+        assertArrayEquals (nacoNormalizer.normalize ("Ðe"), nacoNormalizer.normalize ("De"));
+        assertArrayEquals (nacoNormalizer.normalize ("ðe"), nacoNormalizer.normalize ("de"));
+        // Lowercase Turkish i     I        
+        //assertArrayEquals (nacoNormalizer.normalize ("mecmuası"), nacoNormalizer.normalize ("mecmuasi"));
+        // Polish L        L       Upper and lower case
+        assertArrayEquals (nacoNormalizer.normalize ("Społkanie"), nacoNormalizer.normalize ("Spolkanie"));
+        assertArrayEquals (nacoNormalizer.normalize ("Łuck"), nacoNormalizer.normalize ("Luck"));
+        assertArrayEquals (nacoNormalizer.normalize ("Łuck na Wołyniu"), nacoNormalizer.normalize ("Luck na Wolyniu"));
+        // Script small L  L        
+        assertArrayEquals (nacoNormalizer.normalize ("ℓ"), nacoNormalizer.normalize ("l"));
+        assertArrayEquals (nacoNormalizer.normalize ("\u2113"), nacoNormalizer.normalize ("l"));
+        // O Hook  O       Upper and lower case
+        assertArrayEquals (nacoNormalizer.normalize ("Ơ"), nacoNormalizer.normalize ("O"));
+        assertArrayEquals (nacoNormalizer.normalize ("\u01A0"), nacoNormalizer.normalize ("O"));
+        assertArrayEquals (nacoNormalizer.normalize ("ơ"), nacoNormalizer.normalize ("o"));
+        assertArrayEquals (nacoNormalizer.normalize ("\u01A1"), nacoNormalizer.normalize ("o"));
+        // U Hook  U       Upper and lower case
+        assertArrayEquals (nacoNormalizer.normalize ("Ư"), nacoNormalizer.normalize ("U"));
+        assertArrayEquals (nacoNormalizer.normalize ("\u01AF"), nacoNormalizer.normalize ("U"));
+        assertArrayEquals (nacoNormalizer.normalize ("ư"), nacoNormalizer.normalize ("u"));
+        assertArrayEquals (nacoNormalizer.normalize ("\u01B0"), nacoNormalizer.normalize ("u"));
+        // Scandinavian O  O       Upper and lower case
+        assertArrayEquals (nacoNormalizer.normalize ("Ø"), nacoNormalizer.normalize ("O"));
+        assertArrayEquals (nacoNormalizer.normalize ("ø"), nacoNormalizer.normalize ("o"));
+        // Icelandic Thorn TH      Upper and lower case
+        //assertArrayEquals (nacoNormalizer.normalize ("Þorgils"), nacoNormalizer.normalize ("THorgils"));
+        //assertArrayEquals (nacoNormalizer.normalize ("þor"), nacoNormalizer.normalize ("thor"));
+        // Eszett symbol   SS      Do not use in NACO records
+        assertArrayEquals (nacoNormalizer.normalize ("ß"), nacoNormalizer.normalize ("SS"));
+        assertArrayEquals (nacoNormalizer.normalize ("\u00DF"), nacoNormalizer.normalize ("SS"));
+        // Greek alpha     Uppercase Greek alpha        (U + 0391)      Do not use in NACO 1XX fields
+        assertArrayEquals (nacoNormalizer.normalize ("α"), nacoNormalizer.normalize ("\u0391"));
+        // Greek beta      Uppercase Greek beta (U + 0392)      Do not use in NACO 1XX fields
+        assertArrayEquals (nacoNormalizer.normalize ("β"), nacoNormalizer.normalize ("\u0392"));
+        // Greek gamma     Uppercase Greek gamma        (U + 0393)      Do not use in NACO 1XX fields
+        assertArrayEquals (nacoNormalizer.normalize ("γ"), nacoNormalizer.normalize ("\u0393"));
+    }
+    
+    @Test
+    public void punctuation () {
+        // Exclamation mark        Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("Exclaimation!mark"), nacoNormalizer.normalize ("Exclaimation mark"));
+        assertArrayEquals (nacoNormalizer.normalize ("Exclaimation mark at end!"), nacoNormalizer.normalize ("Exclaimation mark at end"));
+        // Quotation mark  Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("Quotation\"mark"), nacoNormalizer.normalize ("Quotation mark"));
+        // Apostrophe      Delete   
+        assertArrayEquals (nacoNormalizer.normalize ("it's"), nacoNormalizer.normalize ("its"));
+        // Opening parenthesis     Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("Opening(parenthesis"), nacoNormalizer.normalize ("Opening parenthesis"));
+        // Closing parenthesis     Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("Closing)parenthesis"), nacoNormalizer.normalize ("Closing parenthesis"));
+        // Hyphen, minus-  Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("inter-alia"), nacoNormalizer.normalize ("inter alia"));
+        // Opening square bracket  Delete   
+        assertArrayEquals (nacoNormalizer.normalize ("Opening[square bracket"), nacoNormalizer.normalize ("Openingsquare bracket"));
+        // Closing square bracket  Delete   
+        assertArrayEquals (nacoNormalizer.normalize ("Closing]square bracket"), nacoNormalizer.normalize ("Closingsquare bracket"));
+        // Opening curly bracket   Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("Opening{curly bracket"), nacoNormalizer.normalize ("Opening curly bracket"));
+        // Closing curly bracket   Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("Closing}curly bracket"), nacoNormalizer.normalize ("Closing curly bracket"));
+        // Less-than sign  Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("one<three"), nacoNormalizer.normalize ("one three"));
+        // Greater-than sign       Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("three>one"), nacoNormalizer.normalize ("three one"));
+        // Semicolon       Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("semicolon;semicolon"), nacoNormalizer.normalize ("semicolon semicolon"));
+        // Colon:  Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("colon:colon"), nacoNormalizer.normalize ("colon:colon"));
+        // Period, decimal point   Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("19.95"), nacoNormalizer.normalize ("19 95"));
+        assertArrayEquals (nacoNormalizer.normalize ("first.second"), nacoNormalizer.normalize ("first second"));
+        // Question mark   Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("question?mark"), nacoNormalizer.normalize ("question mark"));
+        // Inverted question mark  Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("Inverted¿question¿mark"), 
+                           nacoNormalizer.normalize ("Inverted question mark"));
+        // Inverted exclamation mark       Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("Inverted¡exclamation\u00A1mark"),
+                           nacoNormalizer.normalize ("Inverted exclamation mark"));
+        // comma   Comma or blank  The first comma in $a is retained; all other converted to blank
+        // NOTE: first comma is too fussy right now, all commas will go to blank.
+        assertArrayEquals (nacoNormalizer.normalize ("comma,comma,comma"), nacoNormalizer.normalize ("comma comma comma"));
+
+        // non-NACO extras
+        // LEFT SINGLE QUOTATION MARK      Blank
+        assertArrayEquals (nacoNormalizer.normalize ("left‘quote"), nacoNormalizer.normalize ("left quote"));
+        // RIGHT SINGLE QUOTATION MARK     Blank
+        assertArrayEquals (nacoNormalizer.normalize ("l’enfant"), nacoNormalizer.normalize ("l enfant"));
+        // LEFT DOUBLE QUOTATION MARK      Blank
+        assertArrayEquals (nacoNormalizer.normalize ("left“quote"), nacoNormalizer.normalize ("left quote"));
+        // RIGHT DOUBLE QUOTATION MARK     Blank
+        assertArrayEquals (nacoNormalizer.normalize ("right”quote"), nacoNormalizer.normalize ("right”quote"));
+    }
+    
+    @Test
+    public void otherSpecialCharacters () {
+        // Character       Character       Comments
+        // Music flat sign Retain   
+        // Number sign     Retain   
+        // Slash   Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("slash/slash"), nacoNormalizer.normalize ("slash slash"));
+        // Reverse slash   Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("reverse\\slash"), nacoNormalizer.normalize ("reverse slash"));
+        // Commercial at sign      Retain   
+        // Ampersand       Retain   
+        // Asterisk        Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("asterisk*asterisk"), nacoNormalizer.normalize ("asterisk asterisk"));
+        // Vertical bar (fill)     Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("Vertical|bar"), nacoNormalizer.normalize ("Vertical bar"));
+        // Percent Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("percent%percent"), nacoNormalizer.normalize ("percent percent"));
+        // Equals sign     Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("equals=equals"), nacoNormalizer.normalize ("equals equals"));
+        // Plus sign       Retain   
+        // Plus or minus U+00B1   Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("plus\u00B1or±minus"), nacoNormalizer.normalize ("plus or minus"));
+        // Superscript plus, minus Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("superscript\u207Aplus"), nacoNormalizer.normalize ("superscript plus"));
+        assertArrayEquals (nacoNormalizer.normalize ("superscript\u207Bminus"), nacoNormalizer.normalize ("superscript minus"));
+        // Patent mark     Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("patent®mark"), nacoNormalizer.normalize ("patent mark"));
+        // Sound recording copyright       Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("sound recording℗copyright"), nacoNormalizer.normalize ("sound recording copyright"));
+        // Copyright sign  Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("copyright©sign"), nacoNormalizer.normalize ("copyright sign"));
+        // Dollar sign     Retain   
+        // British pound   Retain   
+        // Degree sign U+00B0     Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("degree°sign"), nacoNormalizer.normalize ("degree sign"));
+        // Spacing circumflex      Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("spacing^circumflex"), nacoNormalizer.normalize ("spacing circumflex"));
+        // Spacing underscore      Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("spacing_underscore"), nacoNormalizer.normalize ("spacing underscore"));
+        // Spacing grave   Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("spacing`grave"), nacoNormalizer.normalize ("spacing grave"));
+        // Spacing tilde   Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("spacing~tilde"), nacoNormalizer.normalize ("spacing tilde"));
+        // Euro sign       Retain  Do not use in NACO records
+        // Music sharp sign        Retain   
+        // Alif U+02BC    Delete   
+        assertArrayEquals (nacoNormalizer.normalize ("alif\u02BCalif"), nacoNormalizer.normalize ("alifalif"));
+        // Ayn U+02BB     Delete   
+        assertArrayEquals (nacoNormalizer.normalize ("ayn\u02BBayn"), nacoNormalizer.normalize ("aynayn"));
+        // Hard sign U+02BA       Delete   
+        assertArrayEquals (nacoNormalizer.normalize ("hard\u02BAsign"), nacoNormalizer.normalize ("hardsign"));
+        // Soft sign U+02B9      Delete   
+        assertArrayEquals (nacoNormalizer.normalize ("soft\u02B9sign"), nacoNormalizer.normalize ("softsign"));
+        // Middle dot U+00B7      Blank    
+        assertArrayEquals (nacoNormalizer.normalize ("middle\u00B7dot"), nacoNormalizer.normalize ("middle dot"));
+    }
+    
+    //
+    // Helpers
+    //
+
+    private List<String> listOf (String ... args) {
+        List<String> result = new ArrayList<String> ();
+        for (String s : args) {
+            result.add (s);
+        }
+
+        return result;
+    }
+
+
+    // http://stackoverflow.com/questions/5108091/java-comparator-for-byte-array-lexicographic
+    private int compareByteArrays (byte[] left, byte[] right) {
+        for (int i = 0, j = 0; i < left.length && j < right.length; i++, j++) {
+            int a = (left[i] & 0xff);
+            int b = (right[j] & 0xff);
+            if (a != b) {
+                return a - b;
+            }
+        }
+        return left.length - right.length;
+    }
+
+
+    private List<String> sort (List<String> list) {
+        List<String> result = new ArrayList<String> ();
+        result.addAll (list);
+
+        Collections.sort (result, new Comparator<String> () {
+                public int compare (String s1, String s2) {
+                    return compareByteArrays (nacoNormalizer.normalize (s1),
+                                              nacoNormalizer.normalize (s2));
+                }
+            });
+
+        return result;
+    }
+
+}

--- a/tests/org/vufind/solr/browse/tests/NACONormalizerTest.java
+++ b/tests/org/vufind/solr/browse/tests/NACONormalizerTest.java
@@ -259,6 +259,10 @@ public class NACONormalizerTest
         assertArrayEquals (nacoNormalizer.normalize ("left“quote"), nacoNormalizer.normalize ("left quote"));
         // RIGHT DOUBLE QUOTATION MARK     Blank
         assertArrayEquals (nacoNormalizer.normalize ("right”quote"), nacoNormalizer.normalize ("right”quote"));
+        // LEFT-POINTING DOUBLE ANGLE QUOTATION MARK      Blank
+        assertArrayEquals (nacoNormalizer.normalize ("left«quote"), nacoNormalizer.normalize ("left quote"));
+        // RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK     Blank
+        assertArrayEquals (nacoNormalizer.normalize ("right»quote"), nacoNormalizer.normalize ("right”quote"));
     }
     
     @Test

--- a/tests/org/vufind/solr/browse/tests/NACONormalizerTest.java
+++ b/tests/org/vufind/solr/browse/tests/NACONormalizerTest.java
@@ -52,7 +52,6 @@ public class NACONormalizerTest
                                     "Banana", "grapefruit",
                                     "   inappropriate leading space",
                                     "Äardvark", "Apple", "AAA")));
-
     }
 
     @Test
@@ -107,10 +106,10 @@ public class NACONormalizerTest
         // High comma centered
         // High comma off center
         // Left hook
-        // Ligature (first/second half)vospominanii︠a︡
-        assertArrayEquals (nacoNormalizer.normalize ("vospominanii︠a︡"), nacoNormalizer.normalize ("vospominaniia"));
-        // Ligature (single) [not in NACO, but we get them in Unicode]
+        // Ligature (single) [current preferred representation]
         assertArrayEquals (nacoNormalizer.normalize ("Novai͡a"), nacoNormalizer.normalize ("Novaia"));
+        // Ligature (first/second half) [older convention]
+        assertArrayEquals (nacoNormalizer.normalize ("vospominanii︠a︡"), nacoNormalizer.normalize ("vospominaniia"));
         // Macron
         assertArrayEquals (nacoNormalizer.normalize ("Pāli"), nacoNormalizer.normalize ("Pali"));
         // Pseudo question mark
@@ -319,6 +318,31 @@ public class NACONormalizerTest
         assertArrayEquals (nacoNormalizer.normalize ("middle\u00B7dot"), nacoNormalizer.normalize ("middle dot"));
     }
     
+    @Test
+    public void obsoleteConversions () {
+        // MODIFIER LETTER LEFT HALF RING <U02BF>       Delete -- formerly used for Ayn
+        assertArrayEquals (nacoNormalizer.normalize ("Mua\u02BFllim"), nacoNormalizer.normalize ("Muallim"));
+    }
+
+    // Some NACO-specific sorting
+
+    @Test
+    public void sortAuthorNames () {
+        assertEquals (listOf ("ʿAbd al-ʿAzīz, Kamāl",
+                              "'Abd al-Bari, 'Abd al-Majid al-Shaykh",
+                              "Abd al-Fattāḥ, Khālid Salīm",
+                              "ʿAbd al-Mawjūd, ʿĀdil Aḥmad",
+                              "ʿAbd al-Qaddūs, Iḥsān",
+                              "ʿAdī, Saʿīd"),
+                sort (listOf ("ʿAbd al-Qaddūs, Iḥsān",
+                              "'Abd al-Bari, 'Abd al-Majid al-Shaykh",
+                              "ʿAdī, Saʿīd",
+                              "ʿAbd al-Mawjūd, ʿĀdil Aḥmad",
+                              "ʿAbd al-ʿAzīz, Kamāl",
+                              "Abd al-Fattāḥ, Khālid Salīm")));
+    }
+
+
     //
     // Helpers
     //

--- a/tests/org/vufind/solr/browse/tests/NormalizerFactoryTest.java
+++ b/tests/org/vufind/solr/browse/tests/NormalizerFactoryTest.java
@@ -2,10 +2,7 @@ package org.vufind.solr.browse.tests;
 
 import static org.junit.Assert.*;
 
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.vufind.util.Normalizer;


### PR DESCRIPTION
This PR adds a normalizer that largely implements the NACO Authority File Comparison Rules:

http://www.loc.gov/aba/pcc/naco/normrule-2.html

Exceptions are listed in the javadoc for the class. There are a couple substitutions that are not yet implemented (one- to two-letter substitutions that might change the implementation strategy) and more types of quotes are handled.

Our language specialists have looked at this for Roman script transliterations and seem satisfied. We plan to roll this into production for our non-callnumber browse indexes.