### PR TITLE
Allow compilation without solr.war

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -25,7 +25,9 @@
   </target>
 
   <target name="setup-solr-war" if="solr.war">
-    <unwar src="${solr.war}" dest="${builddir}/deps/"/>
+    <copy todir="${builddir}/deps/">
+      <fileset dir="${solr.war}"/>
+    </copy>
   </target>
 
 


### PR DESCRIPTION
This allows compilation against Solr 5.3.0, which no longer includes a solr.war file.

TODO:

  - [ ] Better task naming in build.xml
  - [ ] Documentation updates