### PR TITLE
Naco normalizer updates

### DIFF
--- a/common/java/org/vufind/util/NACONormalizer.java
+++ b/common/java/org/vufind/util/NACONormalizer.java
@@ -13,7 +13,7 @@ import com.ibm.icu.text.Collator;
  * Additional normalization:
  * <ol>
  * <li>
- * left and right single and double quotes
+ * single quotes and left and right single and double quotes
  * </li>
  * <li>
  * European-style quotes, «»:<br>
@@ -32,9 +32,6 @@ import com.ibm.icu.text.Collator;
  * </li>
  * <li>
  * eszedt, and thorn are not normalized to their two-character equivalents
- * </li>
- * <li>
- * Inverted question mark is not normalized
  * </li>
  * <li>
  * </li>

--- a/common/java/org/vufind/util/NACONormalizer.java
+++ b/common/java/org/vufind/util/NACONormalizer.java
@@ -54,12 +54,12 @@ public class NACONormalizer implements Normalizer {
     /**
      * Characters that will be deleted during normalization.
      */
-    static private String deleteChars = "['\\[\\]\u02BA\u02BB\u02BC\u02B9\u02BF]";
+    static private String deleteChars = "['\\[\\]‘’\u02BA\u02BB\u02BC\u02B9\u02BF]";
 
     /**
      * Characters that will be converted to spaces during normalization.
      */
-    static private String spaceChars = "[\\p{Punct}¿¡‘’“”«»±⁺⁻℗®©°·]";
+    static private String spaceChars = "[\\p{Punct}¿¡“”«»±⁺⁻℗®©°·]";
 
     /**
      * Pattern to match characters that will be deleted during normalization.

--- a/tests/org/vufind/solr/browse/tests/NACONormalizerTest.java
+++ b/tests/org/vufind/solr/browse/tests/NACONormalizerTest.java
@@ -249,12 +249,20 @@ public class NACONormalizerTest
         // comma   Comma or blank  The first comma in $a is retained; all other converted to blank
         // NOTE: first comma is too fussy right now, all commas will go to blank.
         assertArrayEquals (nacoNormalizer.normalize ("comma,comma,comma"), nacoNormalizer.normalize ("comma comma comma"));
+    }
 
-        // non-NACO extras
-        // LEFT SINGLE QUOTATION MARK      Blank
-        assertArrayEquals (nacoNormalizer.normalize ("left‘quote"), nacoNormalizer.normalize ("left quote"));
-        // RIGHT SINGLE QUOTATION MARK     Blank
-        assertArrayEquals (nacoNormalizer.normalize ("l’enfant"), nacoNormalizer.normalize ("l enfant"));
+    // non-NACO extras
+    // Treat left & right single quotes same as ASCII single quote: delete
+    @Test
+    public void punctuationLeftRightSingleQuotes () {
+        // LEFT SINGLE QUOTATION MARK      Delete
+        assertArrayEquals (nacoNormalizer.normalize ("left‘quote"), nacoNormalizer.normalize ("leftquote"));
+        // RIGHT SINGLE QUOTATION MARK     Delete
+        assertArrayEquals (nacoNormalizer.normalize ("l’enfant"), nacoNormalizer.normalize ("lenfant"));
+    }
+
+    @Test
+    public void punctuationLeftRightDoubleQuotes () {
         // LEFT DOUBLE QUOTATION MARK      Blank
         assertArrayEquals (nacoNormalizer.normalize ("left“quote"), nacoNormalizer.normalize ("left quote"));
         // RIGHT DOUBLE QUOTATION MARK     Blank
@@ -346,7 +354,21 @@ public class NACONormalizerTest
                               "Abd al-Fattāḥ, Khālid Salīm")));
     }
 
+    @Test
+    public void normalizeRussianTitles () {
+        assertArrayEquals(nacoNormalizer.normalize("Mif v folʹklornykh tradit͡sii͡akh i kulʹture noveĭshego vremeni"),
+                nacoNormalizer.normalize("Mif v fol'klornykh tradit͡sii͡akh i kul'ture noveĭshego vremeni"));
+        assertArrayEquals(nacoNormalizer.normalize("Mif v folʹklornykh tradit͡sii͡akh i kulʹture noveĭshego vremeni"),
+                nacoNormalizer.normalize("Mif v folklornykh traditsiiakh i kulture noveĭshego vremeni"));
+    }
 
+    @Test
+    public void singleQuoteLeftRightSingleQuoteEquivalence () {
+        assertArrayEquals(nacoNormalizer.normalize("L'enfant"),
+                nacoNormalizer.normalize("L’enfant"));
+        assertArrayEquals (nacoNormalizer.normalize ("left‘quote"), nacoNormalizer.normalize ("left'quote"));
+        assertArrayEquals (nacoNormalizer.normalize ("l’enfant"), nacoNormalizer.normalize ("l'enfant"));
+    }
     //
     // Helpers
     //


### PR DESCRIPTION
Changed normalization of single-quote plus the left and right single quotes to allow for cases where:
1. right quote is used as apostrophe, and
2. where single-quote or right-single-quote is used in transliteration for Russian soft sign.