### PR TITLE
Solr5 browse updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ jdk:
   - openjdk7
 
 before_script:
-  - wget https://github.com/vufind-org/vufind/raw/master/solr/jetty/webapps/solr.war
+  - wget https://github.com/vufind-org/vufind/archive/v2.5.zip
+  - unzip v2.5.zip
 
 script:
-  - ant test -Dsolr.war=solr.war
+  - ant test -Dvufind.dir=vufind-2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ jdk:
   - openjdk7
 
 before_script:
-  - wget https://github.com/vufind-org/vufind/archive/v2.5.zip
-  - unzip v2.5.zip
+  - wget https://github.com/vufind-org/vufind/archive/solr5.zip
+  - unzip solr5.zip
 
 script:
-  - ant test -Dvufind.dir=vufind-2.5
+  - ant test -Dvufind.dir=vufind-solr5

--- a/README
+++ b/README
@@ -17,7 +17,7 @@
 
  You'll need Ant to get everything compiled:
 
-  ant jars -Dsolr.war=/path/to/my/webapps/solr.war
+  ant jars -Dvufind.dir=/usr/local/vufind
 
  should give you the two required jar files:
 
@@ -146,4 +146,4 @@
 
 Running the unit tests:
 
-     ant test -Dsolr.war=/path/to/my/webapps/solr.war
+     ant test -Dvufind.dir=/usr/local/vufind

--- a/browse-handler/java/org/vufind/solr/handler/BrowseRequestHandler.java
+++ b/browse-handler/java/org/vufind/solr/handler/BrowseRequestHandler.java
@@ -8,7 +8,7 @@ package org.vufind.solr.handler;
 
 
 import org.apache.lucene.document.Document;
-import org.apache.lucene.index.AtomicReaderContext;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.IndexSearcher;
@@ -433,7 +433,7 @@ class BibDB
             bibinfo.put (bibExtras[i], new ArrayList<Collection<String>> ());
         }
 
-        db.search (q, new Collector () {
+        db.search (q, new SimpleCollector () {
                 private int docBase;
 
                 public void setScorer (Scorer scorer) {
@@ -441,6 +441,10 @@ class BibDB
 
                 public boolean acceptsDocsOutOfOrder () {
                     return true;
+                }
+
+                public boolean needsScores () {
+                    return false;
                 }
 
                 public void collect (int docnum) {
@@ -471,7 +475,7 @@ class BibDB
 
                 }
 
-                public void setNextReader (AtomicReaderContext context)
+                public void setNextReader (LeafReaderContext context)
                     throws IOException 
                 {
                     this.docBase = context.docBase;
@@ -789,7 +793,7 @@ public class BrowseRequestHandler extends RequestHandlerBase
      *  {@link SolrRequestHandler#init(NamedList args)} is not defined with a type.
      *  So there's a warning.
      */
-    public void init (NamedList args)
+    public void init (@SuppressWarnings("rawtypes") NamedList args)
     {
         super.init (args);
 

--- a/browse-handler/java/org/vufind/solr/handler/BrowseRequestHandler.java
+++ b/browse-handler/java/org/vufind/solr/handler/BrowseRequestHandler.java
@@ -434,7 +434,7 @@ class BibDB
         }
 
         db.search (q, new SimpleCollector () {
-                private int docBase;
+                private LeafReaderContext context;
 
                 public void setScorer (Scorer scorer) {
                 }
@@ -447,8 +447,13 @@ class BibDB
                     return false;
                 }
 
+                public void doSetNextReader(LeafReaderContext context) {
+                    this.context = context;
+                }
+
+
                 public void collect (int docnum) {
-                    int docid = docnum + docBase;
+                    int docid = docnum + context.docBase;
                     try {
                         Document doc = db.getIndexReader ().document (docid);
 
@@ -473,12 +478,6 @@ class BibDB
                         Log.info ("Exception thrown: " + e);
                     }
 
-                }
-
-                public void setNextReader (LeafReaderContext context)
-                    throws IOException 
-                {
-                    this.docBase = context.docBase;
                 }
             });
 

--- a/browse-indexing/Leech.java
+++ b/browse-indexing/Leech.java
@@ -23,7 +23,7 @@ public class Leech
     public Leech (String indexPath,
                   String field) throws Exception
     {
-        reader = DirectoryReader.open (FSDirectory.open (new File (indexPath)));
+        reader = DirectoryReader.open (FSDirectory.open (new File (indexPath).toPath ()));
         searcher = new IndexSearcher (reader);
         this.field = field;
 
@@ -63,12 +63,12 @@ public class Leech
     public BrowseEntry next () throws Exception
     {
         if (tenum == null) {
-            AtomicReader ir = SlowCompositeReaderWrapper.wrap(reader);
+            LeafReader ir = SlowCompositeReaderWrapper.wrap(reader);
             Terms terms = ir.terms(this.field);
             if (terms == null) {
                 return null;
             }
-            tenum = terms.iterator(null);
+            tenum = terms.iterator();
         }
 
         if (tenum.next() != null) {

--- a/browse-indexing/PrintBrowseHeadings.java
+++ b/browse-indexing/PrintBrowseHeadings.java
@@ -161,7 +161,7 @@ public class PrintBrowseHeadings
         bibLeech = getBibLeech (bibPath, luceneField);
         this.luceneField = luceneField;
 
-        IndexReader bibReader = DirectoryReader.open (FSDirectory.open (new File (bibPath)));
+        IndexReader bibReader = DirectoryReader.open (FSDirectory.open (new File (bibPath).toPath ()));
         bibSearcher = new IndexSearcher (bibReader);
 
         PrintWriter out = new PrintWriter (new FileWriter (outFile));
@@ -171,7 +171,7 @@ public class PrintBrowseHeadings
                                           System.getProperty ("field.insteadof",
                                                               "insteadOf"));
 
-            IndexReader authReader = DirectoryReader.open (FSDirectory.open (new File (authPath)));
+            IndexReader authReader = DirectoryReader.open (FSDirectory.open (new File (authPath).toPath ()));
             authSearcher = new IndexSearcher (authReader);
 
             loadHeadings (nonprefAuthLeech, out,

--- a/browse-indexing/StoredFieldLeech.java
+++ b/browse-indexing/StoredFieldLeech.java
@@ -39,7 +39,7 @@ public class StoredFieldLeech extends Leech
         fieldSelection.add(valueField);
         fieldSelection.add("id");   // make Solr id available for error messages
 
-        reader = DirectoryReader.open (FSDirectory.open (new File (indexPath)));
+        reader = DirectoryReader.open (FSDirectory.open (new File (indexPath).toPath ()));
         buffer = new LinkedList<BrowseEntry> ();
     }
 

--- a/build.xml
+++ b/build.xml
@@ -4,8 +4,7 @@
   <property name="build.sysclasspath" value="last"/>
   <property name="testdir" value="${builddir}/tests"/>
   <property name="testoutputdir" value="${testdir}/output"/>
-  <property name="solr.war" value="../solr/jetty/webapps/solr.war"/>
-  <property name="solr.dir" value="../solr/jetty/webapps/solr/"/>
+  <property name="vufind.dir" value="/usr/local/vufind"/>
   <property name="java.compat.version" value="1.7"/>
   <property name="ant.build.javac.source" value="1.7"/>
   <property name="ant.build.javac.target" value="1.7"/>
@@ -15,19 +14,25 @@
     <fileset dir="${builddir}/deps/"><include name="**/*.jar"/></fileset>
     <fileset dir="libs"><include name="**/*.jar"/></fileset>
     <fileset erroronmissingdir="false" dir="${solr.dir}"><include name="**/*.jar"/></fileset>
+    <fileset erroronmissingdir="false" dir="${vufind.dir}/solr/vendor/dist"><include name="**/*.jar"/></fileset>
+    <fileset erroronmissingdir="false" dir="${vufind.dir}/solr/vendor/server/solr-webapp/webapp/WEB-INF/lib"><include name="**/*.jar"/></fileset>
   </path>
 
   <target name="setup">
     <mkdir dir="${builddir}"/>
     <mkdir dir="${builddir}/deps"/>
     <mkdir dir="${builddir}/bundled-deps"/>
-    <antcall target="setup-solr-war"/>
+    <antcall target="setup-solr-deps"/>
   </target>
 
-  <target name="setup-solr-war" if="solr.war">
-    <unwar src="${solr.war}" dest="${builddir}/deps/"/>
+  <target name="setup-solr-deps">
+    <available file="${vufind.dir}/solr/jetty/webapps/solr.war" property="solr.war.present"/>
+    <antcall target="unpack-solr-war"/>
   </target>
 
+  <target name="unpack-solr-war" if="solr.war.present">
+    <unwar src="${vufind.dir}/solr/jetty/webapps/solr.war" dest="${builddir}/deps/"/>
+  </target>
 
   <target name="build" depends="clean, setup, build-common, build-handler, build-indexing">
   </target>


### PR DESCRIPTION
This PR makes the browse handler compatible with Solr 5; this should not be merged until after the main VuFind project has upgraded to Solr 5 in the standard distribution.

TODO:
- [ ] Adjust Travis configuration to point to a tagged release, once we have a tagged release containing Solr 5.