### PR TITLE
Solr 7 compatibility.

### DIFF
--- a/browse-handler/java/org/vufind/solr/handler/BrowseRequestHandler.java
+++ b/browse-handler/java/org/vufind/solr/handler/BrowseRequestHandler.java
@@ -873,7 +873,7 @@ public class BrowseRequestHandler extends RequestHandlerBase
 
         SolrCore core = req.getCore();
         CoreDescriptor cd = core.getCoreDescriptor();
-        CoreContainer cc = cd.getCoreContainer();
+        CoreContainer cc = core.getCoreContainer();
         SolrCore authCore = cc.getCore(authCoreName);
         //Must decrement RefCounted when finished!
         RefCounted<SolrIndexSearcher> authSearcherRef = authCore.getSearcher();


### PR DESCRIPTION
The Solr API has once again changed in a backward-incompatible way. Once we are ready to upgrade VuFind to Solr 7, we'll also need to merge this PR to master.

@marktriggs, any words of wisdom on a way to achieve this in a backward-compatible way? At a glance, there doesn't seem to be an easy solution, but maybe there's a Java compile-time trick that I'm not aware of. Of course, even if there is a trick, maintaining code that compiles against multiple versions of Solr may not be something we want to do anyway in the long term....