### PR TITLE
Use GitHub vufind master in Travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ dist: trusty
 language: java
 jdk:
   - openjdk8
-php:
-  - 7.1
 
 # addons section is a workaround for a Travis issue with missing JUnit jars:
 addons:
@@ -20,8 +18,7 @@ before_script:
   - if [ ! -d vufind/.git ]; then git clone https://github.com/vufind-org/vufind.git; fi;
   - cd vufind
   - git pull
-  - php -v
-  - phpenv versions
+  - phpenv global 7.1
   - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
   - php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
   - php composer-setup.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
 
 # set up a small VuFind and load some records
 before_script:
-  - if [ ! -d vufind ]; then git clone https://github.com/vufind-org/vufind.git; fi;
+  - if [ ! -d vufind/.git ]; then git clone https://github.com/vufind-org/vufind.git; fi;
   - cd vufind
   - git pull
   - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ dist: trusty
 language: java
 jdk:
   - openjdk8
+php:
+  - 7.1
 
 # addons section is a workaround for a Travis issue with missing JUnit jars:
 addons:
@@ -15,10 +17,14 @@ addons:
 
 # set up a small VuFind and load some records
 before_script:
-  - if [ ! -d downloads ]; then mkdir downloads; fi;
-  - if [ ! -f downloads/vufind-4.0.zip ]; then wget -nv http://downloads.sourceforge.net/vufind/vufind-4.0.zip?use_mirror=osdn -O downloads/vufind-4.0.zip; fi;
-  - unzip -q downloads/vufind-4.0.zip
-  - cd vufind-4.0
+  - if [ ! -d vufind ]; then git clone https://github.com/vufind-org/vufind.git; fi;
+  - cd vufind
+  - git pull
+  - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+  - php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+  - php composer-setup.php
+  - php -r "unlink('composer-setup.php');"
+  - php composer.phar install
   - export VUFIND_HOME=$(pwd)
   - ./solr.sh start
   - ./import-marc-auth.sh tests/data/authority/authorityauth.mrc marc_auth_ils.properties
@@ -32,4 +38,4 @@ script:
 
 cache:
   directories:
-    - downloads
+    - vufind

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_script:
   - cd ..
 
 script:
-  - ant test -Dvufind.dir=vufind-4.0
+  - ant test -Dvufind.dir=vufind
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ before_script:
   - if [ ! -d vufind/.git ]; then git clone https://github.com/vufind-org/vufind.git; fi;
   - cd vufind
   - git pull
+  - php -v
+  - phpenv versions
   - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
   - php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
   - php composer-setup.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,22 +19,20 @@ before_script:
   - cd vufind
   - git pull
   - phpenv global 7.1
-  - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-  - php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-  - php composer-setup.php
-  - php -r "unlink('composer-setup.php');"
-  - php composer.phar install
+  - composer install
   - export VUFIND_HOME=$(pwd)
   - ./solr.sh start
   - ./import-marc-auth.sh tests/data/authority/authorityauth.mrc marc_auth_ils.properties
   - ./import-marc.sh tests/data/authoritybibs.mrc
   - ./index-alphabetic-browse.sh
   - ./solr.sh stop
-  - rm -rf solr/vufind ; git reset --hard
   - cd ..
 
 script:
   - ant test -Dvufind.dir=vufind
+
+after_script:
+  - cd $VUFIND_HOME ; rm -rf solr/vufind ; git reset --hard
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_script:
   - ./import-marc.sh tests/data/authoritybibs.mrc
   - ./index-alphabetic-browse.sh
   - ./solr.sh stop
+  - rm -rf solr/vufind ; git reset --hard
   - cd ..
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ before_script:
 
 script:
   - ant test -Dvufind.dir=vufind
-
-after_script:
   - cd $VUFIND_HOME ; rm -rf solr/vufind ; git reset --hard
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
 
 script:
   - ant test -Dvufind.dir=vufind
-  - cd $VUFIND_HOME ; rm -rf solr/vufind ; git reset --hard
+  - cd $VUFIND_HOME ; rm -rf solr/vufind ; rm import/*.log ; git reset --hard
 
 cache:
   directories:


### PR DESCRIPTION
This allows us to test compatibility with current VuFind developments rather than a fixed release in the .travis.yaml.