### PR TITLE
When we exhaust our term enum's terms, ensure we try the next one

### DIFF
--- a/browse-indexing/Leech.java
+++ b/browse-indexing/Leech.java
@@ -102,7 +102,7 @@ public class Leech
         } else {
             // Exhausted this reader
             tenum = null;
-            return null;
+            return next();
         }
     }
 }


### PR DESCRIPTION
Previously we would return null and stop iteration when this happened,
which isn't the right thing to do.  We should keep going until we've
exhausted all term enums.

@demiankatz This fixes the issue you found where you needed to optimize the index to get everything to show up.  Looks like this was another long(ish) standing bug that only manifested with the Solr 7 upgrade.