### PR TITLE
Add Solr 8 compatibility.

### DIFF
--- a/browse-handler/java/org/vufind/solr/handler/AuthDB.java
+++ b/browse-handler/java/org/vufind/solr/handler/AuthDB.java
@@ -60,7 +60,7 @@ public class AuthDB
                                            heading)),
                                            1));
 
-        if (results.totalHits > 0) {
+        if (results.totalHits.value > 0) {
             return searcher.getIndexReader().document(results.scoreDocs[0].doc);
         } else {
             return null;
@@ -77,7 +77,7 @@ public class AuthDB
 
         List<Document> result = new ArrayList<> ();
 
-        for (int i = 0; i < results.totalHits; i++) {
+        for (int i = 0; i < results.totalHits.value; i++) {
             result.add(searcher.getIndexReader().document(results.scoreDocs[i].doc));
         }
 

--- a/browse-handler/java/org/vufind/solr/handler/BibDB.java
+++ b/browse-handler/java/org/vufind/solr/handler/BibDB.java
@@ -13,6 +13,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.SimpleCollector;
 import org.apache.lucene.search.TermQuery;
@@ -109,6 +110,10 @@ public class BibDB
                 return false;
             }
 
+            public ScoreMode scoreMode() {
+                return ScoreMode.COMPLETE_NO_SCORES;
+            }
+
             public void doSetNextReader(LeafReaderContext context) {
                 this.context = context;
             }
@@ -198,6 +203,10 @@ public class BibDB
 
             public boolean needsScores() {
                 return false;
+            }
+
+            public ScoreMode scoreMode() {
+                return ScoreMode.COMPLETE_NO_SCORES;
             }
 
             public void doSetNextReader(LeafReaderContext context) {
@@ -291,6 +300,10 @@ public class BibDB
 
             public boolean needsScores() {
                 return false;
+            }
+
+            public ScoreMode scoreMode() {
+                return ScoreMode.COMPLETE_NO_SCORES;
             }
 
             public void doSetNextReader(LeafReaderContext context) {

--- a/browse-handler/java/org/vufind/solr/handler/BrowseItem.java
+++ b/browse-handler/java/org/vufind/solr/handler/BrowseItem.java
@@ -154,7 +154,7 @@ public class BrowseItem extends HashMap<String, Object>
 
     public void setCount(int count)
     {
-        this.setCount(new Integer(count));
+        this.setCount(Integer.valueOf(count));
     }
 
     public void setCount(Integer count)

--- a/browse-handler/java/org/vufind/solr/handler/BrowseRequestHandler.java
+++ b/browse-handler/java/org/vufind/solr/handler/BrowseRequestHandler.java
@@ -57,7 +57,7 @@ public class BrowseRequestHandler extends RequestHandlerBase
     {
         super.init(args);
 
-        solrParams = SolrParams.toSolrParams(args);
+        solrParams = args.toSolrParams();
 
         authCoreName = solrParams.get("authCoreName", DFLT_AUTH_CORE_NAME);
 
@@ -91,7 +91,7 @@ public class BrowseRequestHandler extends RequestHandlerBase
     {
         int value;
         try {
-            return new Integer(s).intValue();
+            return Integer.valueOf(s).intValue();
         } catch (NumberFormatException e) {
             return 0;
         }

--- a/browse-indexing/Leech.java
+++ b/browse-indexing/Leech.java
@@ -60,7 +60,7 @@ public class Leech
     {
         try {
             return (this.searcher.search(new ConstantScoreQuery(new TermQuery(new Term(this.field, t))),
-                                         1).totalHits > 0);
+                                         1).totalHits.value > 0);
         } catch (IOException e) {
             return false;
         }


### PR DESCRIPTION
This fixes errors and deprecations encountered while compiling the browse handler against Solr 8; however, it also breaks compatibility with earlier Solr releases.

TODO
- [x] Merge when VuFind upgrades to Solr 8 (see https://github.com/vufind-org/vufind/pull/1477)