### PR TITLE
SolrCloud: look for core names starting with given authority core name

### DIFF
--- a/browse-handler/java/org/vufind/solr/handler/BrowseRequestHandler.java
+++ b/browse-handler/java/org/vufind/solr/handler/BrowseRequestHandler.java
@@ -9,6 +9,7 @@ package org.vufind.solr.handler;
 
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -152,6 +153,15 @@ public class BrowseRequestHandler extends RequestHandlerBase
         CoreDescriptor cd = core.getCoreDescriptor();
         CoreContainer cc = core.getCoreContainer();
         SolrCore authCore = cc.getCore(authCoreName);
+        if (authCore == null) {
+            Collection<String> names = cc.getAllCoreNames();
+            String name = names.stream().filter(n -> n.startsWith(authCoreName)).findFirst().orElse(null);
+            if (name == null)
+                throw new Exception("Could not find a core with a name starting with " + authCoreName);
+            authCore = cc.getCore(name);
+            if (authCore == null)
+                throw new Exception("Could not get the core with the name " + name);
+        }
         //Must decrement RefCounted when finished!
         RefCounted<SolrIndexSearcher> authSearcherRef = authCore.getSearcher();
 


### PR DESCRIPTION
This change will prevent an NPE at [BrowseRequestHandler.java#L156](https://github.com/vufind-org/vufind-browse-handler/blob/cf72dbc3b96689e6e0021f503bf8b875b2fb4435/browse-handler/java/org/vufind/solr/handler/BrowseRequestHandler.java#L156) when SolrCloud is used.
With SolrCloud, the authority core name is something like "authority_shard1_replica_n4", which starts with "authority".
The change will look for core names starting with the given string if no core is found using the exact name. Also it provides a better error message than an NPE if needed.

There is still the assumption that only one shard is used for Solr, but at least it becomes possible to use several replicas.