### PR TITLE
Loosen composer version requirement to fix CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           php-version: '8.0'
           extensions: intl, xsl
-          tools: composer:2.0.13
+          tools: composer:2
 
       - name: Setup Java
         uses: actions/setup-java@v2


### PR DESCRIPTION
The continuous integration build is failing with a Composer error. This PR unpins the Composer version in an effort to fix that problem.