### PR TITLE
Fix deprecations reported when building with Solr 9.3.

### DIFF
--- a/browse-handler/java/org/vufind/solr/handler/AuthDB.java
+++ b/browse-handler/java/org/vufind/solr/handler/AuthDB.java
@@ -61,7 +61,7 @@ public class AuthDB
                                            1));
 
         if (results.totalHits.value > 0) {
-            return searcher.getIndexReader().document(results.scoreDocs[0].doc);
+            return searcher.getIndexReader().storedFields().document(results.scoreDocs[0].doc);
         } else {
             return null;
         }
@@ -78,7 +78,7 @@ public class AuthDB
         List<Document> result = new ArrayList<> ();
 
         for (int i = 0; i < results.totalHits.value; i++) {
-            result.add(searcher.getIndexReader().document(results.scoreDocs[i].doc));
+            result.add(searcher.getIndexReader().storedFields().document(results.scoreDocs[i].doc));
         }
 
         return result;

--- a/browse-handler/java/org/vufind/solr/handler/BibDB.java
+++ b/browse-handler/java/org/vufind/solr/handler/BibDB.java
@@ -224,7 +224,7 @@ public class BibDB
 
                 int docid = docnum + context.docBase;
                 try {
-                    Document doc = db.getIndexReader().document(docid);
+                    Document doc = db.getIndexReader().storedFields().document(docid);
                     for (String bibField : bibExtras) {
                         String[] vals = doc.getValues(bibField);
                         if (vals.length > 0) {
@@ -321,7 +321,7 @@ public class BibDB
 
                 int docid = docnum + context.docBase;
                 try {
-                    Document doc = db.getIndexReader().document(docid);
+                    Document doc = db.getIndexReader().storedFields().document(docid);
                     for (String bibField : bibExtras) {
                         for (String v : doc.getValues(bibField)) {
                             bibinfo.get(bibField).add(v);

--- a/browse-indexing/PrintBrowseHeadings.java
+++ b/browse-indexing/PrintBrowseHeadings.java
@@ -107,7 +107,7 @@ public class PrintBrowseHeadings
         }
 
         for (int i = 0; i < hits.scoreDocs.length; i++) {
-            Document doc = authSearcher.getIndexReader().document(hits.scoreDocs[i].doc);
+            Document doc = authSearcher.getIndexReader().storedFields().document(hits.scoreDocs[i].doc);
 
             String[] preferred = doc.getValues(System.getProperty("field.preferred", "preferred"));
             if (preferred.length > 0) {

--- a/browse-indexing/StoredFieldLeech.java
+++ b/browse-indexing/StoredFieldLeech.java
@@ -47,7 +47,7 @@ public class StoredFieldLeech extends Leech
     private void loadDocument(IndexReader reader, int docid)
     throws Exception
     {
-        Document doc = reader.document(currentDoc, fieldSelection);
+        Document doc = reader.storedFields().document(currentDoc, fieldSelection);
 
         String[] sort_key = doc.getValues(sortField);
         String[] value = doc.getValues(valueField);


### PR DESCRIPTION
When compiled against Solr 9.3, the browse handler reports deprecation warnings. This PR fixes them. We should not merge this until AFTER Solr has been upgraded in the VuFind code. In spite of deprecation warnings, jars built with the old code work correctly for now.

TODO
- [x] Re-run test suite after VuFind dev branch has been upgraded to Solr 9.3 and make sure it passes before merging.