### PR TITLE
Make classes final to eliminate risk of this-escape.

### DIFF
--- a/src/main/java/org/vufind/solr/handler/BrowseItem.java
+++ b/src/main/java/org/vufind/solr/handler/BrowseItem.java
@@ -75,7 +75,7 @@ import org.vufind.solr.handler.client.solrj.BrowseResponse;
  * </table>
  */
 @SuppressWarnings("serial")
-public class BrowseItem extends HashMap<String, Object>
+final public class BrowseItem extends HashMap<String, Object>
 {
     public BrowseItem(String sort_key, String heading)
     {

--- a/src/main/java/org/vufind/solr/handler/BrowseList.java
+++ b/src/main/java/org/vufind/solr/handler/BrowseList.java
@@ -9,7 +9,7 @@ import java.util.Map;
  * browse is positioned from the end of the index.
  */
 @SuppressWarnings("serial")
-public class BrowseList extends ArrayList<BrowseItem>
+final public class BrowseList extends ArrayList<BrowseItem>
 {
     /**
      * The remaining number of headings in the index after the current point in the

--- a/src/main/java/org/vufind/solr/handler/client/solrj/BrowseResponse.java
+++ b/src/main/java/org/vufind/solr/handler/client/solrj/BrowseResponse.java
@@ -24,7 +24,7 @@ import org.apache.solr.common.util.NamedList;
  *
  */
 @SuppressWarnings("serial")
-public class BrowseResponse extends SolrResponseBase
+final public class BrowseResponse extends SolrResponseBase
 {
     // Direct pointers to known types
     private NamedList<String> _header = null;


### PR DESCRIPTION
Compiling the browse handler under Java 21 reveals several this-escape warnings. The easiest solution (based on [a stackoverflow thread about this-escape](https://stackoverflow.com/questions/77191858/what-is-a-this-escape-warning-and-how-do-i-deal-with-it)) is to make the classes final.