### PR TITLE
Compatibility updates for Solr 9.8.1

### DIFF
--- a/src/main/java/org/vufind/solr/handler/BibDB.java
+++ b/src/main/java/org/vufind/solr/handler/BibDB.java
@@ -90,26 +90,28 @@ public class BibDB
         }
 
         int maxHits = (maxBibListSize > 0) ? maxBibListSize : db.count(q);
-        TopDocs docs = db.search(q, maxHits);
+        if (maxHits > 0) {
+            TopDocs docs = db.search(q, maxHits);
 
-        try {
-            for (ScoreDoc sd : docs.scoreDocs) {
-                Document doc = db.getIndexReader().storedFields().document(sd.doc);
-                for (String bibField : bibExtras) {
-                    String[] vals = doc.getValues(bibField);
-                    if (vals.length > 0) {
-                        Collection<String> valSet = new LinkedHashSet<> ();
-                        for (String val : vals) {
-                            valSet.add(val);
+            try {
+                for (ScoreDoc sd : docs.scoreDocs) {
+                    Document doc = db.getIndexReader().storedFields().document(sd.doc);
+                    for (String bibField : bibExtras) {
+                        String[] vals = doc.getValues(bibField);
+                        if (vals.length > 0) {
+                            Collection<String> valSet = new LinkedHashSet<> ();
+                            for (String val : vals) {
+                                valSet.add(val);
+                            }
+                            bibinfo.get(bibField).add(valSet);
                         }
-                        bibinfo.get(bibField).add(valSet);
                     }
                 }
+            } catch (org.apache.lucene.index.CorruptIndexException e) {
+                Log.info("CORRUPT INDEX EXCEPTION.  EEK! - " + e);
+            } catch (Exception e) {
+                Log.info("Exception thrown: " + e);
             }
-        } catch (org.apache.lucene.index.CorruptIndexException e) {
-            Log.info("CORRUPT INDEX EXCEPTION.  EEK! - " + e);
-        } catch (Exception e) {
-            Log.info("Exception thrown: " + e);
         }
 
         return bibinfo;
@@ -154,20 +156,22 @@ public class BibDB
         }
 
         int maxHits = (maxBibListSize > 0) ? maxBibListSize : db.count(q);
-        TopDocs docs = db.search(q, maxHits);
+        if (maxHits > 0) {
+            TopDocs docs = db.search(q, maxHits);
 
-        for (ScoreDoc sd : docs.scoreDocs) {
-            try {
-                Document doc = db.getIndexReader().storedFields().document(sd.doc);
-                for (String bibField : bibExtras) {
-                    for (String v : doc.getValues(bibField)) {
-                        bibinfo.get(bibField).add(v);
+            for (ScoreDoc sd : docs.scoreDocs) {
+                try {
+                    Document doc = db.getIndexReader().storedFields().document(sd.doc);
+                    for (String bibField : bibExtras) {
+                        for (String v : doc.getValues(bibField)) {
+                            bibinfo.get(bibField).add(v);
+                        }
                     }
+                } catch (org.apache.lucene.index.CorruptIndexException e) {
+                    Log.info("CORRUPT INDEX EXCEPTION.  EEK! - " + e);
+                } catch (Exception e) {
+                    Log.info("Exception thrown: " + e);
                 }
-            } catch (org.apache.lucene.index.CorruptIndexException e) {
-                Log.info("CORRUPT INDEX EXCEPTION.  EEK! - " + e);
-            } catch (Exception e) {
-                Log.info("Exception thrown: " + e);
             }
         }
 

--- a/src/main/java/org/vufind/solr/handler/BibDB.java
+++ b/src/main/java/org/vufind/solr/handler/BibDB.java
@@ -14,11 +14,12 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.SimpleCollector;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.search.TotalHitCountCollector;
+import org.apache.lucene.search.TopDocs;
 
 /**
  *
@@ -53,12 +54,7 @@ public class BibDB
     public int recordCount(String heading)
     throws IOException
     {
-        TermQuery q = new TermQuery(new Term(field, heading));
-
-        TotalHitCountCollector counter = new TotalHitCountCollector();
-        db.search(q, counter);
-
-        return counter.getTotalHits();
+        return db.count(new TermQuery(new Term(field, heading)));
     }
 
     /**
@@ -99,61 +95,28 @@ public class BibDB
             bibinfo.put(bibField, new ArrayList<Collection<String>> ());
         }
 
-        db.search(q, new SimpleCollector() {
-            private LeafReaderContext context;
-            private int docCount = 0;
+        int maxHits = (maxBibListSize > 0) ? maxBibListSize : db.count(q);
+        TopDocs docs = db.search(q, maxHits);
 
-            public void setScorer(Scorer scorer) {
-            }
-
-            // Will only be used by other classes
-            @SuppressWarnings("unused")
-            public boolean acceptsDocsOutOfOrder() {
-                return true;
-            }
-
-            public boolean needsScores() {
-                return false;
-            }
-
-            public ScoreMode scoreMode() {
-                return ScoreMode.COMPLETE_NO_SCORES;
-            }
-
-            public void doSetNextReader(LeafReaderContext context) {
-                this.context = context;
-            }
-
-
-            public void collect(int docnum) {
-                // Terminate collection if exceed maximum bibs
-                if (maxBibListSize > 0 && this.docCount >= maxBibListSize) {
-                    throw new CollectionTerminatedException();
-                } else {
-                    this.docCount++;
-                }
-
-                int docid = docnum + context.docBase;
-                try {
-                    Document doc = db.getIndexReader().storedFields().document(docid);
-                    for (String bibField : bibExtras) {
-                        String[] vals = doc.getValues(bibField);
-                        if (vals.length > 0) {
-                            Collection<String> valSet = new LinkedHashSet<> ();
-                            for (String val : vals) {
-                                valSet.add(val);
-                            }
-                            bibinfo.get(bibField).add(valSet);
+        try {
+            for (ScoreDoc sd : docs.scoreDocs) {
+                Document doc = db.getIndexReader().storedFields().document(sd.doc);
+                for (String bibField : bibExtras) {
+                    String[] vals = doc.getValues(bibField);
+                    if (vals.length > 0) {
+                        Collection<String> valSet = new LinkedHashSet<> ();
+                        for (String val : vals) {
+                            valSet.add(val);
                         }
+                        bibinfo.get(bibField).add(valSet);
                     }
-                } catch (org.apache.lucene.index.CorruptIndexException e) {
-                    Log.info("CORRUPT INDEX EXCEPTION.  EEK! - " + e);
-                } catch (Exception e) {
-                    Log.info("Exception thrown: " + e);
                 }
-
             }
-        });
+        } catch (org.apache.lucene.index.CorruptIndexException e) {
+            Log.info("CORRUPT INDEX EXCEPTION.  EEK! - " + e);
+        } catch (Exception e) {
+            Log.info("Exception thrown: " + e);
+        }
 
         return bibinfo;
     }
@@ -196,56 +159,23 @@ public class BibDB
             bibinfo.put(bibField, new LinkedHashSet<String> ());
         }
 
-        db.search(q, new SimpleCollector() {
-            private LeafReaderContext context;
-            private int docCount = 0;
+        int maxHits = (maxBibListSize > 0) ? maxBibListSize : db.count(q);
+        TopDocs docs = db.search(q, maxHits);
 
-            public void setScorer(Scorer scorer) {
-            }
-
-            // Will only be used by other classes
-            @SuppressWarnings("unused")
-            public boolean acceptsDocsOutOfOrder() {
-                return true;
-            }
-
-            public boolean needsScores() {
-                return false;
-            }
-
-            public ScoreMode scoreMode() {
-                return ScoreMode.COMPLETE_NO_SCORES;
-            }
-
-            public void doSetNextReader(LeafReaderContext context) {
-                this.context = context;
-            }
-
-
-            public void collect(int docnum) {
-                // Terminate collection if exceed maximum bibs
-                if (maxBibListSize > 0 && this.docCount >= maxBibListSize) {
-                    throw new CollectionTerminatedException();
-                } else {
-                    this.docCount++;
-                }
-
-                int docid = docnum + context.docBase;
-                try {
-                    Document doc = db.getIndexReader().storedFields().document(docid);
-                    for (String bibField : bibExtras) {
-                        for (String v : doc.getValues(bibField)) {
-                            bibinfo.get(bibField).add(v);
-                        }
+        for (ScoreDoc sd : docs.scoreDocs) {
+            try {
+                Document doc = db.getIndexReader().storedFields().document(sd.doc);
+                for (String bibField : bibExtras) {
+                    for (String v : doc.getValues(bibField)) {
+                        bibinfo.get(bibField).add(v);
                     }
-                } catch (org.apache.lucene.index.CorruptIndexException e) {
-                    Log.info("CORRUPT INDEX EXCEPTION.  EEK! - " + e);
-                } catch (Exception e) {
-                    Log.info("Exception thrown: " + e);
                 }
-
+            } catch (org.apache.lucene.index.CorruptIndexException e) {
+                Log.info("CORRUPT INDEX EXCEPTION.  EEK! - " + e);
+            } catch (Exception e) {
+                Log.info("Exception thrown: " + e);
             }
-        });
+        }
 
         return bibinfo;
     }

--- a/src/main/java/org/vufind/solr/handler/BibDB.java
+++ b/src/main/java/org/vufind/solr/handler/BibDB.java
@@ -4,20 +4,14 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.document.Document;
-import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.ScoreDoc;
-import org.apache.lucene.search.ScoreMode;
-import org.apache.lucene.search.Scorer;
-import org.apache.lucene.search.SimpleCollector;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 

--- a/src/main/java/org/vufind/solr/handler/BrowseRequestHandler.java
+++ b/src/main/java/org/vufind/solr/handler/BrowseRequestHandler.java
@@ -17,7 +17,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.core.CoreContainer;
-import org.apache.solr.core.CoreDescriptor;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.handler.RequestHandlerBase;
 import org.apache.solr.request.SolrRequestHandler;
@@ -92,7 +91,6 @@ public class BrowseRequestHandler extends RequestHandlerBase
 
     private int asInt(String s)
     {
-        int value;
         try {
             return Integer.valueOf(s).intValue();
         } catch (NumberFormatException e) {
@@ -152,7 +150,6 @@ public class BrowseRequestHandler extends RequestHandlerBase
         BrowseSource source = sources.get(sourceName);
 
         SolrCore core = req.getCore();
-        CoreDescriptor cd = core.getCoreDescriptor();
         CoreContainer cc = core.getCoreContainer();
         SolrCore authCore = cc.getCore(authCoreName);
         if (authCore == null) {

--- a/src/main/java/org/vufind/solr/indexing/PrintBrowseHeadings.java
+++ b/src/main/java/org/vufind/solr/indexing/PrintBrowseHeadings.java
@@ -21,7 +21,6 @@ import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TotalHitCountCollector;
 import org.apache.lucene.store.FSDirectory;
 import org.vufind.util.BrowseEntry;
 import org.vufind.util.Utils;
@@ -82,12 +81,7 @@ public class PrintBrowseHeadings
 
     private int bibCount(String heading) throws IOException
     {
-        TotalHitCountCollector counter = new TotalHitCountCollector();
-
-        bibSearcher.search(new ConstantScoreQuery(new TermQuery(new Term(luceneField, heading))),
-                           counter);
-
-        return counter.getTotalHits();
+        return bibSearcher.count(new ConstantScoreQuery(new TermQuery(new Term(luceneField, heading))));
     }
 
 

--- a/src/main/java/org/vufind/util/DeweyCallNormalizer.java
+++ b/src/main/java/org/vufind/util/DeweyCallNormalizer.java
@@ -1,7 +1,7 @@
 package org.vufind.util;
 
 import org.marc4j.callnum.DeweyCallNumber;
-import java.util.logging.Logger;
+// import java.util.logging.Logger;
 
 public class DeweyCallNormalizer implements Normalizer
 {
@@ -17,5 +17,5 @@ public class DeweyCallNormalizer implements Normalizer
         return key;
     }
 
-    private static final Logger log = Logger.getLogger(DeweyCallNormalizer.class.getName());
+    // private static final Logger log = Logger.getLogger(DeweyCallNormalizer.class.getName());
 }

--- a/src/main/java/org/vufind/util/LCCallNormalizer.java
+++ b/src/main/java/org/vufind/util/LCCallNormalizer.java
@@ -1,7 +1,7 @@
 package org.vufind.util;
 
 import org.marc4j.callnum.LCCallNumber;
-import java.util.logging.Logger;
+// import java.util.logging.Logger;
 
 public class LCCallNormalizer implements Normalizer
 {
@@ -17,5 +17,5 @@ public class LCCallNormalizer implements Normalizer
         return key;
     }
 
-    private static final Logger log = Logger.getLogger(LCCallNormalizer.class.getName());
+    // private static final Logger log = Logger.getLogger(LCCallNormalizer.class.getName());
 }

--- a/tests/org/vufind/solr/handler/BibDBTest.java
+++ b/tests/org/vufind/solr/handler/BibDBTest.java
@@ -329,4 +329,45 @@ public class BibDBTest
             searcherRef.decref();
         }
     }
+
+    /**
+     * Test method for {@link org.vufind.solr.handler.BibDB#matchingFields(java.lang.String, java.lang.String, int)}.
+     */
+    @Test
+    public void testMatchingFields_noMatchFound()
+    {
+        String title = "This title does not exist in our test data";
+        RefCounted<SolrIndexSearcher> searcherRef = bibCore.getSearcher();
+        IndexSearcher searcher = searcherRef.get();
+        try {
+            BibDB bibDbForTitle = new BibDB(searcher, "title_fullStr");
+            assertEquals(bibDbForTitle.matchingFields(title, "id", 0).get("id").size(), 0);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Caught exception with unmatched title: " + e.getMessage());
+        } finally {
+            searcherRef.decref();
+        }
+    }
+
+    /**
+     * Test method for {@link org.vufind.solr.handler.BibDB#matchingExtras(java.lang.String, java.lang.String, int)}.
+     */
+    @Test
+    public void testMatchingExtras_noMatchFound()
+    {
+        String title = "This title does not exist in our test data";
+        RefCounted<SolrIndexSearcher> searcherRef = bibCore.getSearcher();
+        IndexSearcher searcher = searcherRef.get();
+        try {
+            BibDB bibDbForTitle = new BibDB(searcher, "title_fullStr");
+            assertEquals(bibDbForTitle.matchingExtras(title, "id", 0).get("id").size(), 0);
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Caught exception with unmatched title: " + e.getMessage());
+        } finally {
+            searcherRef.decref();
+        }
+    }
+
 }

--- a/tests/org/vufind/solr/handler/tests/BrowseHandlerTest.java
+++ b/tests/org/vufind/solr/handler/tests/BrowseHandlerTest.java
@@ -147,7 +147,7 @@ public class BrowseHandlerTest
         paramList.add("source","title");
         paramList.add("from","a");
         paramList.add("extras", extras);
-        SolrParams params = SolrParams.toSolrParams(paramList);
+        SolrParams params = paramList.toSolrParams();
 
         /* RUN */
         // do something with your search component


### PR DESCRIPTION
@demiankatz I've rejiggered things a little for Solr 9.8.1 with the hope of future-proofing a bit while I'm at it.  I've got the unit tests passing, but I don't have a really good VuFind test setup running at the moment.  If things don't look right, let me know and I'll get my environment resurrected :)

------------------
The `IndexSearcher.search(query, collector)` method is now deprecated. We used custom collectors in several places: sometimes just to count numbers of results; other times because we wanted to walk a full result set but didn't care about relevance ranking.

The places using TotalHitCountCollector can be replaced by a call to IndexSearcher.count(), so no problem there.

For the BibDB, which used to use a custom Collector, I've switched it to use a standard call to IndexSearcher(query, limit) and to process the resulting TopDocs.  Using the higher-level API should hopefully be more future-proof.

It does mean we're now firing the query twice (once to get the result count, once to accumulate the results into the right-sized array), and it also means we're now computing relevance ranking scores we don't use.  But the queries involved are so simple that neither of these overheads will be noticeable to end users.