### PR TITLE
Raise target Java version to 11; eliminate compilation warnings.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -13,9 +13,8 @@
   <!-- The solr.install.dir property was added to work around an issue in the Solr 9.1 test suite;
        it can probably be safely removed once VuFind upgrades to Solr 9.2 or higher. -->
   <property name="solr.install.dir" value="${absolute.vufind.dir}/solr/vendor"/>
-  <property name="java.compat.version" value="1.8"/>
-  <property name="ant.build.javac.source" value="1.8"/>
-  <property name="ant.build.javac.target" value="1.8"/>
+  <property name="java.compat.version" value="11"/>
+  <property name="ant.build.javac.release" value="11"/>
 
   <path id="classpath">
     <pathelement location="${builddir}"/>

--- a/build.xml
+++ b/build.xml
@@ -80,6 +80,7 @@
     <javac debug="on" srcdir="src/main/java" destdir="${builddir}">
       <classpath refid="classpath"/>
       <compilerarg value="-Xlint"/>
+      <compilerarg value="-proc:none"/>
     </javac>
     <exec executable="sh" output="${builddir}/VERSION">
       <arg value="-c"/>


### PR DESCRIPTION
VuFind has required Java 11 since release 9.0 due to Solr requirement increases, so it seems sensible to make the browse handler requirements match, especially because compilation was emitting warnings about `-source 8` being deprecated. This also replaces the old `source`/`target` compilation switches with the unified `release` option (for simplicity and to prevent warnings) and disables unnecessary annotation processing (to avoid additional warnings).