### PR TITLE
Pass our release target version through to javac

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -14,7 +14,6 @@
        it can probably be safely removed once VuFind upgrades to Solr 9.2 or higher. -->
   <property name="solr.install.dir" value="${absolute.vufind.dir}/solr/vendor"/>
   <property name="java.compat.version" value="11"/>
-  <property name="ant.build.javac.release" value="11"/>
 
   <path id="classpath">
     <pathelement location="${builddir}"/>
@@ -77,7 +76,8 @@
     <!-- <pathconvert property="classpathProp" refid="classpath"/> -->
     <!-- <echo>Classpath: ${classpathProp}</echo> -->
     <mkdir dir="${builddir}"/>
-    <javac debug="on" srcdir="src/main/java" destdir="${builddir}">
+    <javac debug="on" srcdir="src/main/java" destdir="${builddir}"
+           release="${java.compat.version}">
       <classpath refid="classpath"/>
       <compilerarg value="-Xlint"/>
       <compilerarg value="-proc:none"/>
@@ -164,6 +164,7 @@
             depends="build">
       <mkdir dir="${testdir}"/>
       <javac fork="true" debug="on" srcdir="tests/" destdir="${testdir}"
+             release="${java.compat.version}"
              classpath="tests/lib/*:${toString:classpath}:${builddir}">
         <compilerarg line="-encoding UTF-8" />
       </javac>


### PR DESCRIPTION
The `java.compat.version` and `ant.build.javac.release` properties weren't automatically applying.  Explicitly set our version when invoking javac to ensure that jars built with the latest JDK will still run on earlier supported JDKs.